### PR TITLE
Make it work under window.plugins

### DIFF
--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -3,49 +3,65 @@
  * Reused and ported to Android plugin by Daniel van 't Oever
  */
 
-var exec = require('cordova/exec');
+// var exec = require('cordova/exec');
 /**
  * Constructor
  */
 function DatePicker() {
-    //this._callback;
+  //this._callback;
 }
 
-	/**
-	 * show - true to show the ad, false to hide the ad
-	 */
-	DatePicker.prototype.show = function(options, cb) {
-		if (options.date) {
-			options.date = (options.date.getMonth() + 1) + "/" + (options.date.getDate()) + "/" + (options.date.getFullYear()) + "/"
-					+ (options.date.getHours()) + "/" + (options.date.getMinutes());
-		}
-		var defaults = {
-			mode : '',
-			date : '',
-			minDate: 0,
-			maxDate: 0
-		};
+/**
+ * show - true to show the ad, false to hide the ad
+ */
+DatePicker.prototype.show = function(options, cb) {
+  
+  if (options.date) {
+    options.date = (options.date.getMonth() + 1) + "/" + 
+                   (options.date.getDate()) + "/" + 
+                   (options.date.getFullYear()) + "/" + 
+                   (options.date.getHours()) + "/" + 
+                   (options.date.getMinutes());
+  }
 
-		for ( var key in defaults) {
-			if (typeof options[key] !== "undefined")
-				defaults[key] = options[key];
-		}
-		//this._callback = cb;
+  var defaults = {
+    mode : '',
+    date : '',
+    minDate: 0,
+    maxDate: 0
+  };
 
-		var callback = function(message) {
-			cb(new Date(message));
-		}
-		
-		exec(callback, 
-		  null, 
-		  "DatePickerPlugin", 
-		  defaults.mode,
-		  [defaults]
-		);
-		
-		//return gap.exec(cb, failureCallback, 'DatePickerPlugin', defaults.mode, new Array(defaults));
-		
-	};
+  for (var key in defaults) {
+    if (typeof options[key] !== "undefined") {
+      defaults[key] = options[key];
+    }
+  }
 
-var datePicker = new DatePicker();
-module.exports = datePicker
+  //this._callback = cb;
+
+  var callback = function(message) {
+    cb(new Date(message));
+  }
+  
+  cordova.exec(callback, 
+    null, 
+    "DatePickerPlugin", 
+    defaults.mode,
+    [defaults]
+  );
+  
+  //return gap.exec(cb, failureCallback, 'DatePickerPlugin', defaults.mode, new Array(defaults));
+};
+
+//-------------------------------------------------------------------
+
+if(!window.plugins) {
+    window.plugins = {};
+}
+if (!window.plugins.datePicker) {
+    window.plugins.datePicker = new DatePicker();
+}
+
+if (module.exports) {
+  module.exports = window.plugins.datePicker;
+}


### PR DESCRIPTION
require throw errors in Cordova -v = 3.4.0-0.1.3. Cordova.exec is already available. Add the plugin under window.plugins object.
