### PR TITLE
simple format should use HH to return 24 hour format

### DIFF
--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -243,7 +243,7 @@ public class DatePickerPlugin extends CordovaPlugin {
 		 */
 		@Override
 		public void onTimeSet(final TimePicker view, final int hourOfDay, final int minute) {
-			SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd hh:mm:ss");
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 			Date date = new Date();
 			date.setHours(hourOfDay);
 			date.setMinutes(minute);


### PR DESCRIPTION
Since the android picker uses 24 hour view, the returned date should also formatted in 24 hours, else it will result in bugs. 
