### PR TITLE
Added support for `minuteInterval` on iOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ Type: String
 
 Default: `0`
 
+### minuteInterval - iOS
+Interval between options in the minute section of the date picker.
+
+Type: Integer
+
+Default: `1`
+
 ## Requirements
 - PhoneGap 3.0 or newer / Cordova 3.0 or newer
 - Android 2.3.1 or newer / iOS 5 or newer

--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -196,6 +196,7 @@
   BOOL allowFutureDates = ([[options objectForKey:@"allowFutureDates"] intValue] == 0) ? NO : YES;
   NSString *minDateString = [options objectForKey:@"minDate"];
   NSString *maxDateString = [options objectForKey:@"maxDate"];
+  NSInteger minuteInterval = [options objectForKey:@"minuteInterval"];
   
   if (!allowOldDates) {
     self.datePicker.minimumDate = [NSDate date];
@@ -222,6 +223,10 @@
     self.datePicker.datePickerMode = UIDatePickerModeTime;
   } else {
     self.datePicker.datePickerMode = UIDatePickerModeDateAndTime;
+  }
+
+  if (minuteInterval) {
+    self.datePicker.minuteInterval = minuteInterval;
   }
 }
 

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -68,7 +68,8 @@ DatePicker.prototype.show = function(options, cb) {
         cancelButtonLabel: 'Cancel',
         cancelButtonColor: '#000000',
         x: '0',
-        y: '0'
+        y: '0',
+        minuteInterval: 1
     };
 
     for (var key in defaults) {


### PR DESCRIPTION
Xcode documentation [here](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIDatePicker_Class/index.html#//apple_ref/occ/instm/UIDatePicker/minuteInterval)
