### PR TITLE
Fixed `minuteInterval` problem.

### DIFF
--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -196,7 +196,8 @@
   BOOL allowFutureDates = ([[options objectForKey:@"allowFutureDates"] intValue] == 0) ? NO : YES;
   NSString *minDateString = [options objectForKey:@"minDate"];
   NSString *maxDateString = [options objectForKey:@"maxDate"];
-  NSInteger minuteInterval = [options objectForKey:@"minuteInterval"];
+  NSString *minuteIntervalString = [options objectForKey:@"minuteInterval"];
+  NSInteger minuteInterval = [minuteIntervalString integerValue];
   
   if (!allowOldDates) {
     self.datePicker.minimumDate = [NSDate date];


### PR DESCRIPTION
Integer wasn't being communicated properly in Objective-C.

I thought I had changed this in the actual repo code but had only changed it in my prototype code; apologies.
