### PR TITLE
when user cancels selection, do not call success callback

### DIFF
--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -39,7 +39,10 @@ DatePicker.prototype.show = function(options, cb) {
 	//this._callback = cb;
 
 	var callback = function(message) {
-		cb(new Date(message));
+		var timestamp = Date.parse(message);
+		if(isNaN(timestamp) == false) {
+			cb(new Date(message));
+		}
 	}
   
 	cordova.exec(callback, 


### PR DESCRIPTION
When user cancels a selection in the datepicker plugin, the success callback is called with "cancel". This causes the resulting date to be NaN. With this pull request the success callback is not called.
