### PR TITLE
Fix issue with datepicker instantiation on iOS 8.1

### DIFF
--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -166,9 +166,10 @@
   UIView *datePickerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, pickerViewWidth, pickerViewHeight)];
   
   CGRect frame = CGRectMake(0, 0, 0, 0);
-  if(!self.datePicker){
-    self.datePicker = [self createDatePicker:options frame:frame];
-    [self.datePicker addTarget:self action:@selector(dateChangedAction:) forControlEvents:UIControlEventValueChanged];
+  // in iOS8, UIDatePicker couldn't be shared in multi UIViews, it will cause crash. so   create new UIDatePicker instance every time
+  if (! self.datePicker || [[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0){
+      self.datePicker = [self createDatePicker:options frame:frame];
+      [self.datePicker addTarget:self action:@selector(dateChangedAction:) forControlEvents:UIControlEventValueChanged];
   }
   [self updateDatePicker:options];
   [datePickerView addSubview:self.datePicker];


### PR DESCRIPTION
There is an issue with iPads on iOS8.1 (and possibly other devices) where if you have multiple Datepickers on the form the second one will throw "UITableView dataSource is not set" error.
See: https://github.com/VitaliiBlagodir/cordova-plugin-datepicker/issues/44
