### PR TITLE
Removing Deprecated iOS Method Usage.

### DIFF
--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -139,15 +139,16 @@
 
 - (void)jsCancel {
   NSLog(@"JS Cancel is going to be executed");
-  NSString* jsCallback = [NSString stringWithFormat:@"datePicker._dateSelectionCanceled();"];
-  [super writeJavascript:jsCallback];
+  NSString *jsCallback = @"datePicker._dateSelectionCanceled();";
+    
+  [self.commandDelegate evalJs:jsCallback];
 }
 
 - (void)jsDateSelected {
   NSTimeInterval seconds = [self.datePicker.date timeIntervalSince1970];
-  NSString* jsCallback = [NSString stringWithFormat:@"datePicker._dateSelected(\"%f\");", seconds];
-  //NSLog(jsCallback);
-  [super writeJavascript:jsCallback];
+  NSString *jsCallback = [NSString stringWithFormat:@"datePicker._dateSelected(\"%f\");", seconds];
+    
+  [self.commandDelegate evalJs:jsCallback];
 }
 
 


### PR DESCRIPTION
Fixes VitaliiBlagodir/cordova-plugin-datepicker#30
Using `[self.commandDelegate evalJs:jsCallback]` instead of `[self writeJavascript:jsCallabck]`, as it has been deprecated as of Cordova 3.6.
Updating jsCancel to just use a string directly -- no need to run it through stringWithFormat.