### PR TITLE
Added "is24HourView" option for android devices time picker

### DIFF
--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -61,14 +61,14 @@ public class DatePickerPlugin extends CordovaPlugin {
 		final Runnable runnable;
 
 		String action = "date";
-		Boolean is24HourView = false;
 		long minDateLong = 0, maxDateLong = 0;
 
 		int month = -1, day = -1, year = -1, hour = -1, min = -1;
+        boolean is24HourView = false;
 		try {
 			JSONObject obj = data.getJSONObject(0);
 			action = obj.getString("mode");
-			is24HourView = obj.getString("is24HourView");
+			is24HourView = obj.getBoolean("is24HourView");
 
 			String optionDate = obj.getString("date");
 
@@ -92,6 +92,7 @@ public class DatePickerPlugin extends CordovaPlugin {
 		final int mDay = day == -1 ? c.get(Calendar.DAY_OF_MONTH) : day;
 		final int mHour = hour == -1 ? c.get(Calendar.HOUR_OF_DAY) : hour;
 		final int mMinutes = min == -1 ? c.get(Calendar.MINUTE) : min;
+        final boolean mIs24HourView = is24HourView;
 
 		final long minDate = minDateLong;
 		final long maxDate = maxDateLong;
@@ -102,8 +103,7 @@ public class DatePickerPlugin extends CordovaPlugin {
 				public void run() {
 					final TimeSetListener timeSetListener = new TimeSetListener(datePickerPlugin, callbackContext);
 					final TimePickerDialog timeDialog = new TimePickerDialog(currentCtx, timeSetListener, mHour,
-							mMinutes, false);
-					timeDialog.setIs24HourView(is24HourView);
+							mMinutes, mIs24HourView);
 					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
 						timeDialog.setCancelable(true);
 						timeDialog.setCanceledOnTouchOutside(false);

--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -61,12 +61,14 @@ public class DatePickerPlugin extends CordovaPlugin {
 		final Runnable runnable;
 
 		String action = "date";
+		Boolean is24HourView = false;
 		long minDateLong = 0, maxDateLong = 0;
 
 		int month = -1, day = -1, year = -1, hour = -1, min = -1;
 		try {
 			JSONObject obj = data.getJSONObject(0);
 			action = obj.getString("mode");
+			is24HourView = obj.getString("is24HourView");
 
 			String optionDate = obj.getString("date");
 
@@ -101,6 +103,7 @@ public class DatePickerPlugin extends CordovaPlugin {
 					final TimeSetListener timeSetListener = new TimeSetListener(datePickerPlugin, callbackContext);
 					final TimePickerDialog timeDialog = new TimePickerDialog(currentCtx, timeSetListener, mHour,
 							mMinutes, false);
+					timeDialog.setIs24HourView(is24HourView);
 					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
 						timeDialog.setCancelable(true);
 						timeDialog.setCanceledOnTouchOutside(false);

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -23,11 +23,16 @@ DatePicker.prototype.show = function(options, cb) {
 					   (options.date.getMinutes());
 	}
 
+	if (options.is24HourView) {
+			options.is24HourView = is24HourView;
+	}
+
 	var defaults = {
 		mode : 'date',
 		date : '',
 		minDate: 0,
-		maxDate: 0
+		maxDate: 0,
+		is24HourView: false
 	};
 
 	for (var key in defaults) {

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -24,7 +24,7 @@ DatePicker.prototype.show = function(options, cb) {
 	}
 
 	if (options.is24HourView) {
-			options.is24HourView = is24HourView;
+			options.is24HourView = options.is24HourView;
 	}
 
 	var defaults = {


### PR DESCRIPTION
I needed to get rid of the "AM/PM" to switch to french time formatting so I just added the option the plugin options.
