### PR TITLE
Android code refactored, added new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,9 @@
-# DatePicker Plugin for Cordova/PhoneGap 4.0 (iOS and Android and Windows), Ionic 1.3 (tested on Android and iOS)
+# DatePicker Plugin for Cordova/PhoneGap 4.0 (iOS and Android and Windows)
 
-Original version https://github.com/VitaliiBlagodir/cordova-plugin-datepicker
+This is a combined version of DatePicker iOS and Android and Windows plugin for Cordova/Phonegap 4.0.
+- Original iOS version: https://github.com/sectore/phonegap3-ios-datepicker-plugin
 
-New in this fork (Android Only):
-
-- Android code refactored
-
-- Option datetime added (default if mode is unknown), opening a new time dialog after setting the date
-
-- Options okText and cancelText to define the labels for POSITIVE and NEGATIVE buttons
-
-- Option todayText to set the label of a button that selects current date (date and datetime)
-
-- Option nowText to set the label of a button that selects current time (time and datetime)
-
-- Option is24Hour added
+- Original Android version: https://github.com/bikasv/cordova-android-plugins/tree/master/datepicker
 
 ## Installation
 
@@ -23,17 +12,12 @@ New in this fork (Android Only):
 2) Add a plugin to your project using Cordova CLI:
 
 ```bash
-cordova plugin add https://github.com/andrelsmoraes/cordova-plugin-datepicker.git
+cordova plugin add https://github.com/VitaliiBlagodir/cordova-plugin-datepicker
 ```
 Or using PhoneGap CLI:
 
 ```bash
-phonegap local plugin add https://github.com/andrelsmoraes/cordova-plugin-datepicker.git
-```
-Or using Ionic CLI:
-
-```bash
-ionic plugin add https://github.com/andrelsmoraes/cordova-plugin-datepicker.git
+phonegap local plugin add https://github.com/VitaliiBlagodir/cordova-plugin-datepicker
 ```
 
 ## Usage
@@ -56,7 +40,7 @@ The mode of the date picker.
 
 Type: String
 
-Values: `date` | `time` | `datetime`
+Values: `date` | `time` | `datetime` (iOS, Windows only)
 
 Default: `date`
 
@@ -76,49 +60,13 @@ Default: `(empty String)`
 
 minDate is a Date object for iOS and an integer for Android, so you need to account for that when using the plugin.
 
+
 ### maxDate - iOS, Android, Windows
 Maximum date.
 
 Type: Date | empty String
 
 Default: `(empty String)` 
-
-### okText - Android
-Label of BUTTON_POSITIVE (done button). If empty, uses android.R.string.ok.
-
-Type: String | empty String
-
-Default: `(empty String)` 
-
-### cancelText - Android
-Label of BUTTON_NEGATIVE (cancel button). If empty, uses android.R.string.cancel.
-
-Type: String | empty String
-
-Default: `(empty String)` 
-
-### todayText - Android
-Label of today button. If empty, doesn't show the option to select current date.
-
-Type: String | empty String
-
-Default: `(empty String)` 
-
-### nowText - Android
-Label of now button. If empty, doesn't show the option to select current time.
-
-Type: String | empty String
-
-Default: `(empty String)` 
-
-### is24Hour - Android
-Shows time dialog in 24 hours format.
-
-Type: Boolean
-
-Values: `true` | `false`
-
-Default: `false`
 
 ### allowOldDates - iOS
 Shows or hide dates earlier then selected date.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# DatePicker Plugin for Cordova/PhoneGap 4.0 (iOS and Android and Windows)
+# DatePicker Plugin for Cordova/PhoneGap 4.0 (iOS and Android and Windows), Ionic 1.3 (tested on Android and iOS)
 
-This is a combined version of DatePicker iOS and Android and Windows plugin for Cordova/Phonegap 4.0.
-- Original iOS version: https://github.com/sectore/phonegap3-ios-datepicker-plugin
+Original version https://github.com/VitaliiBlagodir/cordova-plugin-datepicker
 
-- Original Android version: https://github.com/bikasv/cordova-android-plugins/tree/master/datepicker
+New in this fork (Android Only):
+
+- Android code refactored
+
+- Option datetime added (default if mode is unknown), opening a new time dialog after setting the date
+
+- Options okText and cancelText to define the labels for POSITIVE and NEGATIVE buttons
+
+- Option todayText to set the label of a button that selects current date (date and datetime)
+
+- Option nowText to set the label of a button that selects current time (time and datetime)
+
+- Option is24Hour added
 
 ## Installation
 
@@ -12,12 +23,17 @@ This is a combined version of DatePicker iOS and Android and Windows plugin for 
 2) Add a plugin to your project using Cordova CLI:
 
 ```bash
-cordova plugin add https://github.com/VitaliiBlagodir/cordova-plugin-datepicker
+cordova plugin add https://github.com/andrelsmoraes/cordova-plugin-datepicker.git
 ```
 Or using PhoneGap CLI:
 
 ```bash
-phonegap local plugin add https://github.com/VitaliiBlagodir/cordova-plugin-datepicker
+phonegap local plugin add https://github.com/andrelsmoraes/cordova-plugin-datepicker.git
+```
+Or using Ionic CLI:
+
+```bash
+ionic plugin add https://github.com/andrelsmoraes/cordova-plugin-datepicker.git
 ```
 
 ## Usage
@@ -40,7 +56,7 @@ The mode of the date picker.
 
 Type: String
 
-Values: `date` | `time` | `datetime` (iOS, Windows only)
+Values: `date` | `time` | `datetime`
 
 Default: `date`
 
@@ -60,13 +76,49 @@ Default: `(empty String)`
 
 minDate is a Date object for iOS and an integer for Android, so you need to account for that when using the plugin.
 
-
 ### maxDate - iOS, Android, Windows
 Maximum date.
 
 Type: Date | empty String
 
 Default: `(empty String)` 
+
+### okText - Android
+Label of BUTTON_POSITIVE (done button). If empty, uses android.R.string.ok.
+
+Type: String | empty String
+
+Default: `(empty String)` 
+
+### cancelText - Android
+Label of BUTTON_NEGATIVE (cancel button). If empty, uses android.R.string.cancel.
+
+Type: String | empty String
+
+Default: `(empty String)` 
+
+### todayText - Android
+Label of today button. If empty, doesn't show the option to select current date.
+
+Type: String | empty String
+
+Default: `(empty String)` 
+
+### nowText - Android
+Label of now button. If empty, doesn't show the option to select current time.
+
+Type: String | empty String
+
+Default: `(empty String)` 
+
+### is24Hour - Android
+Shows time dialog in 24 hours format.
+
+Type: Boolean
+
+Values: `true` | `false`
+
+Default: `false`
 
 ### allowOldDates - iOS
 Shows or hide dates earlier then selected date.

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.plugin.datepicker"
-    version="0.8.0">
+    id="cordova-plugin-datepicker"
+    version="0.7.1">
 
     <name>DatePicker</name>
 
@@ -13,7 +13,7 @@
 
     <keywords>cordova,phonegap,datepicker,android,ios,ios7,ios8,wp</keywords>
 
-    <repo>https://github.com/andrelsmoraes/cordova-plugin-datepicker.git</repo>
+    <repo>https://github.com/VitaliiBlagodir/cordova-plugin-datepicker.git</repo>
 
     <!-- android -->
     <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-datepicker"
-    version="0.7.1">
+    id="com.plugin.datepicker"
+    version="0.7.0">
 
     <name>DatePicker</name>
 
@@ -13,7 +13,7 @@
 
     <keywords>cordova,phonegap,datepicker,android,ios,ios7,ios8,wp</keywords>
 
-    <repo>https://github.com/VitaliiBlagodir/cordova-plugin-datepicker.git</repo>
+    <repo>https://github.com/andrelsmoraes/cordova-plugin-datepicker.git</repo>
 
     <!-- android -->
     <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.plugin.datepicker"
-    version="0.7.0">
+    version="0.8.0">
 
     <name>DatePicker</name>
 

--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -2,15 +2,20 @@
  * @author Bikas Vaibhav (http://bikasv.com) 2013
  * Rewrote the plug-in at https://github.com/phonegap/phonegap-plugins/tree/master/Android/DatePicker
  * It can now accept `min` and `max` dates for DatePicker.
+ *
+ * @author Andre Moraes (https://github.com/andrelsmoraes)
+ * Refactored code, changed default mode to show date and time dialog.
+ * Added options `okText`, `cancelText`, `todayText`, `nowText`, `is24Hour`.
  */
 
 package com.plugin.datepicker;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.TimeZone;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
 
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -18,34 +23,33 @@ import org.json.JSONObject;
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;
-import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.os.Build;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.widget.DatePicker;
 import android.widget.DatePicker.OnDateChangedListener;
 import android.widget.TimePicker;
 
-import org.apache.cordova.CordovaWebView;
-import org.apache.cordova.CallbackContext;
-import org.apache.cordova.CordovaPlugin;
-
-import android.os.Build;
-
-@SuppressWarnings("deprecation")
 @SuppressLint("NewApi")
 public class DatePickerPlugin extends CordovaPlugin {
 
 	private static final String ACTION_DATE = "date";
 	private static final String ACTION_TIME = "time";
+	private static final String RESULT_ERROR = "error";
 	private final String pluginName = "DatePickerPlugin";
+	
+	// On some devices, onDateSet or onTimeSet are being called twice
+	private boolean called = false;
+	private boolean canceled = false;
 
 	@Override
 	public boolean execute(final String action, final JSONArray data, final CallbackContext callbackContext) {
 		Log.d(pluginName, "DatePicker called with options: " + data);
+		called = false;
+		canceled = false;
 		boolean result = false;
 
 		this.show(data, callbackContext);
@@ -55,209 +59,214 @@ public class DatePickerPlugin extends CordovaPlugin {
 	}
 
 	public synchronized void show(final JSONArray data, final CallbackContext callbackContext) {
-		final DatePickerPlugin datePickerPlugin = this;
-		final Context currentCtx = cordova.getActivity();
-		final Calendar c = Calendar.getInstance();
-		final Runnable runnable;
-		String action = "date";
-		String clearText = "Clear";
-	
-		long minDateLong = 0, maxDateLong = 0;
+		DatePickerPlugin datePickerPlugin = this;
+		Context currentCtx = cordova.getActivity();
+		Runnable runnable;
+		JsonDate jsonDate = new JsonDate().fromJson(data);
 		
-		int month = -1, day = -1, year = -1, hour = -1, min = -1;
-		try {
-			JSONObject obj = data.getJSONObject(0);
-			action = obj.getString("mode");
-
-			String optionDate = obj.getString("date");
-
-			String[] datePart = optionDate.split("/");
-			month = Integer.parseInt(datePart[0]);
-			day = Integer.parseInt(datePart[1]);
-			year = Integer.parseInt(datePart[2]);
-			hour = Integer.parseInt(datePart[3]);
-			min = Integer.parseInt(datePart[4]);
-
-			minDateLong = obj.getLong("minDate");
-			maxDateLong = obj.getLong("maxDate");
-
-	
-
-		} catch (JSONException e) {
-			e.printStackTrace();
-		}
-
-		// By default initalize these fields to 'now'
-		final int mYear = year == -1 ? c.get(Calendar.YEAR) : year;
-		final int mMonth = month == -1 ? c.get(Calendar.MONTH) : month - 1;
-		final int mDay = day == -1 ? c.get(Calendar.DAY_OF_MONTH) : day;
-		final int mHour = hour == -1 ? c.get(Calendar.HOUR_OF_DAY) : hour;
-		final int mMinutes = min == -1 ? c.get(Calendar.MINUTE) : min;
-
-		final long minDate = minDateLong;
-		final long maxDate = maxDateLong;
-		final String clearButtonText = clearText;
-
-	
-
-		if (ACTION_TIME.equalsIgnoreCase(action)) {
-			runnable = new Runnable() {
-				@Override
-				public void run() {
-					final TimeSetListener timeSetListener = new TimeSetListener(datePickerPlugin, callbackContext);
-					final TimePickerDialog timeDialog = new TimePickerDialog(currentCtx, timeSetListener, mHour,
-							mMinutes, false);
-					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-						timeDialog.setCancelable(true);
-						timeDialog.setCanceledOnTouchOutside(false);
-						if (!clearButtonText.isEmpty()){
-							
-	                        timeDialog.setButton(TimePickerDialog.BUTTON_NEUTRAL, clearButtonText, new DialogInterface.OnClickListener() {
-	                        	@Override
-	                            public void onClick(DialogInterface dialog, int which) {
-	                                // TODO Auto-generated method stub
-	                                callbackContext.success("-1");                                
-	                            }
-	                        });
-                        }
-						timeDialog.setButton(DialogInterface.BUTTON_NEGATIVE, currentCtx.getString(android.R.string.cancel), new DialogInterface.OnClickListener() {
-							@Override
-							public void onClick(DialogInterface dialog, int which) {
-								callbackContext.success("cancel");
-							}
-						});
-						timeDialog.setOnKeyListener(new Dialog.OnKeyListener() {
-							@Override
-							public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
-								// TODO Auto-generated method stub
-								//callbackContext.success("");
-								return false;
-							}
-						});
-					}
-					timeDialog.show();
-				}
-			};
-
-		} else if (ACTION_DATE.equalsIgnoreCase(action)) {
-			runnable = new Runnable() {
-				@Override
-				public void run() {
-					final DateSetListener dateSetListener = new DateSetListener(datePickerPlugin, callbackContext);
-					final DatePickerDialog dateDialog = new DatePickerDialog(currentCtx, dateSetListener, mYear,
-							mMonth, mDay);
-					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-						DatePicker dp = dateDialog.getDatePicker();
-						if(minDate > 0) {
-							dp.setMinDate(minDate);
-						}
-						if(maxDate > 0 && maxDate > minDate) {
-							dp.setMaxDate(maxDate);
-						}
-
-						dateDialog.setCancelable(true);
-						dateDialog.setCanceledOnTouchOutside(false);
-						dateDialog.setButton(DialogInterface.BUTTON_NEGATIVE, currentCtx.getString(android.R.string.cancel), new DialogInterface.OnClickListener() {
-				            @Override
-				            public void onClick(DialogInterface dialog, int which) {
-								callbackContext.success("cancel");
-				            }
-				        });
-						dateDialog.setOnKeyListener(new Dialog.OnKeyListener() {
-							@Override
-							public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
-								// TODO Auto-generated method stub
-								//callbackContext.success("");
-								return false;
-							}
-						});
-					}
-					else {
-						java.lang.reflect.Field mDatePickerField = null;
-						try {
-							mDatePickerField = dateDialog.getClass().getDeclaredField("mDatePicker");
-						} catch (NoSuchFieldException e) {
-							// TODO Auto-generated catch block
-							e.printStackTrace();
-						}
-						mDatePickerField.setAccessible(true);
-						DatePicker pickerView = null;
-						try {
-							pickerView = (DatePicker) mDatePickerField.get(dateDialog);
-						} catch (IllegalArgumentException e) {
-							e.printStackTrace();
-						} catch (IllegalAccessException e) {
-							e.printStackTrace();
-						}
-
-						final Calendar startDate = Calendar.getInstance();
-						startDate.setTimeInMillis(minDate);
-						final Calendar endDate = Calendar.getInstance();
-						endDate.setTimeInMillis(maxDate);
-
-						final int minYear = startDate.get(Calendar.YEAR);
-					    final int minMonth = startDate.get(Calendar.MONTH);
-					    final int minDay = startDate.get(Calendar.DAY_OF_MONTH);
-					    final int maxYear = endDate.get(Calendar.YEAR);
-					    final int maxMonth = endDate.get(Calendar.MONTH);
-					    final int maxDay = endDate.get(Calendar.DAY_OF_MONTH);
-
-						if(startDate !=null || endDate != null) {
-							pickerView.init(mYear, mMonth, mDay, new OnDateChangedListener() {
-				                @Override
-								public void onDateChanged(DatePicker view, int year, int month, int day) {
-				                	if(maxDate > 0 && maxDate > minDate) {
-					                	if(year > maxYear || month > maxMonth && year == maxYear || day > maxDay && year == maxYear && month == maxMonth){
-					                		view.updateDate(maxYear, maxMonth, maxDay);
-					                	}
-				                	}
-				                	if(minDate > 0) {
-					                	if(year < minYear || month < minMonth && year == minYear || day < minDay && year == minYear && month == minMonth) {
-					                		view.updateDate(minYear, minMonth, minDay);
-					                	}
-				                	}
-			                	}
-				            });
-						}
-					}
-					dateDialog.show();
-				}
-			};
+		if (ACTION_TIME.equalsIgnoreCase(jsonDate.action)) {
+			runnable = runnableTimeDialog(datePickerPlugin, currentCtx,
+					callbackContext, jsonDate, Calendar.getInstance(TimeZone.getDefault()));
 
 		} else {
-			Log.d(pluginName, "Unknown action. Only 'date' or 'time' are valid actions");
-			return;
+			runnable = runnableDatePicker(datePickerPlugin, currentCtx, callbackContext, jsonDate);
 		}
 
 		cordova.getActivity().runOnUiThread(runnable);
 	}
+	
+	private Runnable runnableTimeDialog(final DatePickerPlugin datePickerPlugin,
+			final Context currentCtx, final CallbackContext callbackContext,
+			final JsonDate jsonDate, final Calendar calendarDate) {
+		return new Runnable() {
+			@Override
+			public void run() {
+				final TimeSetListener timeSetListener = new TimeSetListener(datePickerPlugin, callbackContext, calendarDate);
+				final TimePickerDialog timeDialog = new TimePickerDialog(currentCtx, timeSetListener, jsonDate.hour,
+						jsonDate.minutes, jsonDate.is24Hour);
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+					timeDialog.setCancelable(true);
+					timeDialog.setCanceledOnTouchOutside(false);
+					if (!jsonDate.nowText.isEmpty()){
+						timeDialog.setButton(DialogInterface.BUTTON_NEUTRAL, jsonDate.nowText, new DialogInterface.OnClickListener() {
+							@Override
+							public void onClick(DialogInterface dialog, int which) {
+								Calendar now = Calendar.getInstance();
+			                	timeDialog.updateTime(now.get(Calendar.HOUR_OF_DAY), now.get(Calendar.MINUTE));
+							}
+						});
+			        }
+					String labelCancel = jsonDate.cancelText.isEmpty() ? currentCtx.getString(android.R.string.cancel) : jsonDate.cancelText; 
+					timeDialog.setButton(DialogInterface.BUTTON_NEGATIVE, labelCancel, new DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int which) {
+							canceled = true;
+						}
+					});
+					String labelOk = jsonDate.okText.isEmpty() ? currentCtx.getString(android.R.string.ok) : jsonDate.okText;
+					timeDialog.setButton(DialogInterface.BUTTON_POSITIVE, labelOk, new DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int which) {
+						}
+					});
+				}
+				timeDialog.show();
+			}
+		};
+	}
+	
+	private Runnable runnableDatePicker(
+			final DatePickerPlugin datePickerPlugin, final Context currentCtx,
+			final CallbackContext callbackContext, final JsonDate jsonDate) {
+		return new Runnable() {
+			@Override
+			public void run() {
+				final DateSetListener dateSetListener = new DateSetListener(datePickerPlugin, callbackContext, jsonDate);
+				final DatePickerDialog dateDialog = new DatePickerDialog(currentCtx, dateSetListener, jsonDate.year,
+						jsonDate.month, jsonDate.day);
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+					prepareDialog(dateDialog, callbackContext, currentCtx, jsonDate);
+				}
+				else {
+					prepareDialogPreHoneycomb(dateDialog, callbackContext, currentCtx, jsonDate);
+				}
+				dateDialog.show();
+			}
+		};
+	}
+	
+	private void prepareDialog(final DatePickerDialog dateDialog,
+			final CallbackContext callbackContext, Context currentCtx, JsonDate jsonDate) {
+		
+		DatePicker dp = dateDialog.getDatePicker();
+		if(jsonDate.minDate > 0) {
+			dp.setMinDate(jsonDate.minDate);
+		}
+		if(jsonDate.maxDate > 0 && jsonDate.maxDate > jsonDate.minDate) {
+			dp.setMaxDate(jsonDate.maxDate);
+		}
+
+		dateDialog.setCancelable(true);
+		dateDialog.setCanceledOnTouchOutside(false);
+		if (!jsonDate.todayText.isEmpty()){
+            dateDialog.setButton(DialogInterface.BUTTON_NEUTRAL, jsonDate.todayText, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                	Calendar now = Calendar.getInstance();
+                	dateDialog.updateDate(now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH));
+                }
+            });
+        }
+		String labelCancel = jsonDate.cancelText.isEmpty() ? currentCtx.getString(android.R.string.cancel) : jsonDate.cancelText; 
+		dateDialog.setButton(DialogInterface.BUTTON_NEGATIVE, labelCancel, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+				canceled = true;
+            }
+        });
+		String labelOk = jsonDate.okText.isEmpty() ? currentCtx.getString(android.R.string.ok) : jsonDate.okText;
+		dateDialog.setButton(DialogInterface.BUTTON_POSITIVE, labelOk, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+            }
+        });
+	}
+	
+	private void prepareDialogPreHoneycomb(DatePickerDialog dateDialog,
+			final CallbackContext callbackContext, Context currentCtx, final JsonDate jsonDate){
+		java.lang.reflect.Field mDatePickerField = null;
+		try {
+			mDatePickerField = dateDialog.getClass().getDeclaredField("mDatePicker");
+		} catch (NoSuchFieldException e) {
+			callbackContext.error(RESULT_ERROR);
+		}
+		mDatePickerField.setAccessible(true);
+		DatePicker pickerView = null;
+		try {
+			pickerView = (DatePicker) mDatePickerField.get(dateDialog);
+		} catch (IllegalArgumentException e) {
+			callbackContext.error(RESULT_ERROR);
+		} catch (IllegalAccessException e) {
+			callbackContext.error(RESULT_ERROR);
+		}
+
+		final Calendar startDate = Calendar.getInstance();
+		startDate.setTimeInMillis(jsonDate.minDate);
+		final Calendar endDate = Calendar.getInstance();
+		endDate.setTimeInMillis(jsonDate.maxDate);
+
+		final int minYear = startDate.get(Calendar.YEAR);
+	    final int minMonth = startDate.get(Calendar.MONTH);
+	    final int minDay = startDate.get(Calendar.DAY_OF_MONTH);
+	    final int maxYear = endDate.get(Calendar.YEAR);
+	    final int maxMonth = endDate.get(Calendar.MONTH);
+	    final int maxDay = endDate.get(Calendar.DAY_OF_MONTH);
+
+		if(startDate !=null || endDate != null) {
+			pickerView.init(jsonDate.year, jsonDate.month, jsonDate.day, new OnDateChangedListener() {
+                @Override
+				public void onDateChanged(DatePicker view, int year, int month, int day) {
+                	if(jsonDate.maxDate > 0 && jsonDate.maxDate > jsonDate.minDate) {
+	                	if(year > maxYear || month > maxMonth && year == maxYear || day > maxDay && year == maxYear && month == maxMonth){
+	                		view.updateDate(maxYear, maxMonth, maxDay);
+	                	}
+                	}
+                	if(jsonDate.minDate > 0) {
+	                	if(year < minYear || month < minMonth && year == minYear || day < minDay && year == minYear && month == minMonth) {
+	                		view.updateDate(minYear, minMonth, minDay);
+	                	}
+                	}
+            	}
+            });
+		}
+	}
 
 	private final class DateSetListener implements OnDateSetListener {
+		private JsonDate jsonDate;
 		private final DatePickerPlugin datePickerPlugin;
 		private final CallbackContext callbackContext;
 
-		private DateSetListener(DatePickerPlugin datePickerPlugin, CallbackContext callbackContext) {
+		private DateSetListener(DatePickerPlugin datePickerPlugin, CallbackContext callbackContext, JsonDate jsonDate) {
 			this.datePickerPlugin = datePickerPlugin;
 			this.callbackContext = callbackContext;
+			this.jsonDate = jsonDate;
 		}
 
 		/**
-		 * Return a string containing the date in the format YYYY/MM/DD
+		 * Return a string containing the date in the format YYYY/MM/DD or call TimeDialog if action != date
 		 */
 		@Override
 		public void onDateSet(final DatePicker view, final int year, final int monthOfYear, final int dayOfMonth) {
-			String returnDate = year + "/" + (monthOfYear + 1) + "/" + dayOfMonth;
-			callbackContext.success(returnDate);
+			if (canceled || called) {
+				return;
+			}
+			called = true;
+			canceled = false;
+			
+			if (ACTION_DATE.equalsIgnoreCase(jsonDate.action)) {
+				String returnDate = year + "/" + (monthOfYear + 1) + "/" + dayOfMonth;
+				callbackContext.success(returnDate);
+			
+			} else {
+				// Open time dialog
+				Calendar selectedDate = Calendar.getInstance();
+				selectedDate.set(Calendar.YEAR, year);
+				selectedDate.set(Calendar.MONTH, monthOfYear);
+				selectedDate.set(Calendar.DAY_OF_MONTH, dayOfMonth);
+				
+				cordova.getActivity().runOnUiThread(runnableTimeDialog(datePickerPlugin, cordova.getActivity(),
+						callbackContext, jsonDate, selectedDate));
+			}
 		}
 	}
 
 	private final class TimeSetListener implements OnTimeSetListener {
-		private final DatePickerPlugin datePickerPlugin;
+		private Calendar calendarDate;
 		private final CallbackContext callbackContext;
 
-		private TimeSetListener(DatePickerPlugin datePickerPlugin, CallbackContext callbackContext) {
-			this.datePickerPlugin = datePickerPlugin;
+		private TimeSetListener(DatePickerPlugin datePickerPlugin, CallbackContext callbackContext, Calendar selectedDate) {
 			this.callbackContext = callbackContext;
+			this.calendarDate = selectedDate != null ? selectedDate : Calendar.getInstance();
 		}
 
 		/**
@@ -266,15 +275,71 @@ public class DatePickerPlugin extends CordovaPlugin {
 		 */
 		@Override
 		public void onTimeSet(final TimePicker view, final int hourOfDay, final int minute) {
-			Calendar calendar = Calendar.getInstance(TimeZone.getDefault());
-			calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
-			calendar.set(Calendar.MINUTE, minute);
+			if (canceled) {
+				return;
+			}
+			
+			calendarDate.set(Calendar.HOUR_OF_DAY, hourOfDay);
+			calendarDate.set(Calendar.MINUTE, minute);
+			calendarDate.set(Calendar.SECOND, 0);
 
 			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 			sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-			String toReturn = sdf.format(calendar.getTime());
+			String toReturn = sdf.format(calendarDate.getTime());
 
 			callbackContext.success(toReturn);
+		}
+	}
+	
+	private final class JsonDate {
+		
+		private String action = "date";
+		private String okText, cancelText, todayText = "", nowText = "";
+		private long minDate = 0, maxDate = 0;
+		private int month, day, year, hour, minutes;
+		private boolean is24Hour = false;
+		
+		public JsonDate() {
+			reset(Calendar.getInstance());
+		}
+		
+		private void reset(Calendar c) {
+			year = c.get(Calendar.YEAR);
+			month = c.get(Calendar.MONTH);
+			day = c.get(Calendar.DAY_OF_MONTH);
+			hour = c.get(Calendar.HOUR_OF_DAY);
+			minutes = c.get(Calendar.MINUTE);
+		}
+		
+		public JsonDate fromJson(JSONArray data) {
+			try {
+				JSONObject obj = data.getJSONObject(0);
+				action = obj.getString("mode");
+				
+				String optionDate = obj.getString("date");
+
+				String[] datePart = optionDate.split("/");
+				month = Integer.parseInt(datePart[0]) - 1;
+				day = Integer.parseInt(datePart[1]);
+				year = Integer.parseInt(datePart[2]);
+				hour = Integer.parseInt(datePart[3]);
+				minutes = Integer.parseInt(datePart[4]);
+
+				minDate = obj.has("minDate") ? obj.getLong("minDate") : 0l;
+				maxDate = obj.has("maxDate") ? obj.getLong("maxDate") : 0l;
+				
+				okText = obj.has("okText") ? obj.getString("okText") : "";
+				cancelText = obj.has("cancelText") ? obj.getString("cancelText") : "";
+				todayText = obj.has("todayText") ? obj.getString("todayText") : "";
+				nowText = obj.has("nowText") ? obj.getString("nowText") : "";
+				is24Hour = obj.has("is24Hour") ? obj.getBoolean("is24Hour")
+						: false;
+				
+			} catch (JSONException e) {
+				reset(Calendar.getInstance());
+			}
+						
+			return this;
 		}
 	}
 

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -28,7 +28,11 @@ DatePicker.prototype.show = function(options, cb) {
 		date : '',
 		minDate: 0,
 		maxDate: 0,
-		clearText: 'Clear'
+		cancelText: '',
+		okText: '',
+		todayText: '',
+		nowText: '',
+		is24Hour: false
 	};
 
 	for (var key in defaults) {
@@ -40,9 +44,7 @@ DatePicker.prototype.show = function(options, cb) {
 	//this._callback = cb;
 
 	var callback = function(message) {
-		if(message == -1){
-			cb(message);
-		} else {
+		if(message != 'error'){
 			var timestamp = Date.parse(message);
 			if(isNaN(timestamp) == false) {
 				cb(new Date(message));
@@ -50,6 +52,8 @@ DatePicker.prototype.show = function(options, cb) {
 	        else {
 	            cb();
 	        }
+		} else {
+			// TODO error popup?
     	}
 	}
 


### PR DESCRIPTION
All changes are for Android:
- Code refactored: logic into smaller functions;
- Option datetime added (default if mode is unknown), opening a new time dialog after setting the date;
- Options okText and cancelText to define the labels for POSITIVE and NEGATIVE buttons;
- Option todayText to set the label of a button that selects current date (date and datetime);
- Option nowText to set the label of a button that selects current time (time and datetime);
- Option is24Hour added (time and datetime);
- Removed option clearText, it was setting date to 1970;
- Changed error return to "error" instead of "-1".