### PR TITLE
Retrieve typed values in Android when field is still in focus

### DIFF
--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -124,6 +124,7 @@ public class DatePickerPlugin extends CordovaPlugin {
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
 							if (timePicker != null) {
+								timePicker.clearFocus();
 								Calendar now = Calendar.getInstance();
 								timeSetListener.onTimeSet(timePicker, timePickerHour, timePickerMinute);
 							}
@@ -185,6 +186,7 @@ public class DatePickerPlugin extends CordovaPlugin {
             @Override
             public void onClick(DialogInterface dialog, int which) {
 				DatePicker datePicker = dateDialog.getDatePicker();
+				datePicker.clearFocus();
 				dateListener.onDateSet(datePicker, datePicker.getYear(), datePicker.getMonth(), datePicker.getDayOfMonth());
             }
         });


### PR DESCRIPTION
When typing, Android picker's onDateSet/onTimeSet method is only called when an input loses focus.
Pickers can now clear the focus when the positive button is clicked, and retrieve the most up to date
value entered.