### PR TITLE
implements Android themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ Values: `true` | `false`
 
 Default: `false`
 
+### androidTheme - Android
+Choose the theme of the picker
+
+Type: Int
+
+Values: `THEME_TRADITIONAL | THEME_HOLO_DARK | THEME_HOLO_LIGHT | THEME_DEVICE_DEFAULT_DARK | THEME_DEVICE_DEFAULT_LIGHT`
+
+Default: `THEME_TRADITIONAL`
+
 ### allowOldDates - iOS
 Shows or hide dates earlier then selected date.
 

--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -65,13 +65,17 @@ public class DatePickerPlugin extends CordovaPlugin {
 		Context currentCtx = cordova.getActivity();
 		Runnable runnable;
 		JsonDate jsonDate = new JsonDate().fromJson(data);
-		
+		    
+    // Retrieve Android theme
+    JSONObject options = data.optJSONObject(0);
+    int theme = options.optInt("androidTheme", 1);
+
 		if (ACTION_TIME.equalsIgnoreCase(jsonDate.action)) {
-			runnable = runnableTimeDialog(datePickerPlugin, currentCtx,
+			runnable = runnableTimeDialog(datePickerPlugin, theme, currentCtx,
 					callbackContext, jsonDate, Calendar.getInstance(TimeZone.getDefault()));
 
 		} else {
-			runnable = runnableDatePicker(datePickerPlugin, currentCtx, callbackContext, jsonDate);
+			runnable = runnableDatePicker(datePickerPlugin, theme, currentCtx, callbackContext, jsonDate);
 		}
 
 		cordova.getActivity().runOnUiThread(runnable);
@@ -82,13 +86,13 @@ public class DatePickerPlugin extends CordovaPlugin {
 	private int timePickerMinute = 0;
 	
 	private Runnable runnableTimeDialog(final DatePickerPlugin datePickerPlugin,
-			final Context currentCtx, final CallbackContext callbackContext,
+			final int theme, final Context currentCtx, final CallbackContext callbackContext,
 			final JsonDate jsonDate, final Calendar calendarDate) {
 		return new Runnable() {
 			@Override
 			public void run() {
 				final TimeSetListener timeSetListener = new TimeSetListener(datePickerPlugin, callbackContext, calendarDate);
-				final TimePickerDialog timeDialog = new TimePickerDialog(currentCtx, timeSetListener, jsonDate.hour,
+				final TimePickerDialog timeDialog = new TimePickerDialog(currentCtx, theme, timeSetListener, jsonDate.hour,
 						jsonDate.minutes, jsonDate.is24Hour) {
 					public void onTimeChanged(TimePicker view, int hourOfDay, int minute) {
 						timePicker = view;
@@ -138,13 +142,14 @@ public class DatePickerPlugin extends CordovaPlugin {
 	}
 	
 	private Runnable runnableDatePicker(
-			final DatePickerPlugin datePickerPlugin, final Context currentCtx,
+			final DatePickerPlugin datePickerPlugin,
+			final int theme, final Context currentCtx,
 			final CallbackContext callbackContext, final JsonDate jsonDate) {
 		return new Runnable() {
 			@Override
 			public void run() {
-				final DateSetListener dateSetListener = new DateSetListener(datePickerPlugin, callbackContext, jsonDate);
-				final DatePickerDialog dateDialog = new DatePickerDialog(currentCtx, dateSetListener, jsonDate.year,
+				final DateSetListener dateSetListener = new DateSetListener(datePickerPlugin, theme, callbackContext, jsonDate);
+				final DatePickerDialog dateDialog = new DatePickerDialog(currentCtx, theme, dateSetListener, jsonDate.year,
 						jsonDate.month, jsonDate.day);
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
 					prepareDialog(dateDialog, dateSetListener, callbackContext, currentCtx, jsonDate);
@@ -251,11 +256,13 @@ public class DatePickerPlugin extends CordovaPlugin {
 		private JsonDate jsonDate;
 		private final DatePickerPlugin datePickerPlugin;
 		private final CallbackContext callbackContext;
+		private final int theme;
 
-		private DateSetListener(DatePickerPlugin datePickerPlugin, CallbackContext callbackContext, JsonDate jsonDate) {
+		private DateSetListener(DatePickerPlugin datePickerPlugin, int theme, CallbackContext callbackContext, JsonDate jsonDate) {
 			this.datePickerPlugin = datePickerPlugin;
 			this.callbackContext = callbackContext;
 			this.jsonDate = jsonDate;
+      this.theme = theme;
 		}
 
 		/**
@@ -286,7 +293,7 @@ public class DatePickerPlugin extends CordovaPlugin {
 				selectedDate.set(Calendar.MONTH, monthOfYear);
 				selectedDate.set(Calendar.DAY_OF_MONTH, dayOfMonth);
 				
-				cordova.getActivity().runOnUiThread(runnableTimeDialog(datePickerPlugin, cordova.getActivity(),
+				cordova.getActivity().runOnUiThread(runnableTimeDialog(datePickerPlugin, theme, cordova.getActivity(),
 						callbackContext, jsonDate, selectedDate));
 			}
 		}

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -11,6 +11,17 @@ function DatePicker() {
 }
 
 /**
+ * Android themes
+ */
+DatePicker.prototype.ANDROID_THEMES = {
+  THEME_TRADITIONAL          : 1, // default
+  THEME_HOLO_DARK            : 2,
+  THEME_HOLO_LIGHT           : 3,
+  THEME_DEVICE_DEFAULT_DARK  : 4,
+  THEME_DEVICE_DEFAULT_LIGHT : 5
+};
+
+/**
  * show - true to show the ad, false to hide the ad
  */
 DatePicker.prototype.show = function(options, cb, errCb) {
@@ -32,7 +43,8 @@ DatePicker.prototype.show = function(options, cb, errCb) {
 		okText: '',
 		todayText: '',
 		nowText: '',
-		is24Hour: false
+		is24Hour: false,
+    androidTheme : window.datePicker.ANDROID_THEMES.THEME_TRADITIONAL, // Default theme
 	};
 
 	for (var key in defaults) {


### PR DESCRIPTION
Hi !

I use this plugin to avoid input date types but I think it really lacks a feature : Android themes.
Based on [this](https://github.com/EddyVerbruggen/cordova-plugin-actionsheet/commit/72fcf4bc728c774df1b6474679c7fe570659bf65) PR, I implement this feature for this plugin.

This is how to use it :

```
var options = {
    date: new Date(),
    mode: 'date',
    androidTheme: window.datePicker.ANDROID_THEMES.THEME_DEVICE_DEFAULT_LIGHT
};
 
function onSuccess(date) {
    alert('Selected date: ' + date);
}
 
function onError(error) { // Android only 
    alert('Error: ' + error);
}
 
datePicker.show(options, onSuccess, onError);
```

and you should get this on a device running Lollipop :

![picker](https://cloud.githubusercontent.com/assets/3125705/8699609/017452f6-2b07-11e5-95d6-5e3515d9f221.png)

Available themes :
```
DatePicker.prototype.ANDROID_THEMES = {
  THEME_TRADITIONAL          : 1, // default
  THEME_HOLO_DARK            : 2,
  THEME_HOLO_LIGHT           : 3,
  THEME_DEVICE_DEFAULT_DARK  : 4,
  THEME_DEVICE_DEFAULT_LIGHT : 5
};`
```