### PR TITLE
Fix Orientation Change on iOS

### DIFF
--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -57,6 +57,8 @@
   CGFloat width;
   CGFloat height;
   
+  [self.datePickerContainer removeFromSuperview];
+  
   if(UIInterfaceOrientationIsLandscape(deviceOrientation)){
     width = self.webView.superview.frame.size.height;
     height= self.webView.superview.frame.size.width;


### PR DESCRIPTION
On iOS 8, changing device orientation was crashing the plugin.