### PR TITLE
Ghost click issue using Ionic

### DIFF
--- a/src/windows/DatePickerProxy.js
+++ b/src/windows/DatePickerProxy.js
@@ -118,6 +118,7 @@ module.exports = {
 
                     var timePickerSelect = document.createElement("select");
                     timePickerSelect.style.cssText = buttonCSSText;
+                    timePickerSelect.setAttribute("data-tap-disabled","true");
 
                     cell.appendChild(timePickerSelect);
 
@@ -184,7 +185,7 @@ module.exports = {
 
                     var datePickerSelect = document.createElement("select");
                     datePickerSelect.style.cssText = buttonCSSText;
-
+                    datePickerSelect.setAttribute("data-tap-disabled","true");
                     if (i == 0) {
                         datePickerSelect.id = "winjsdatepickerYear";
                         descriptionElement.textContent = "year";


### PR DESCRIPTION
This issue is strictly the problem of this plugin, but without this change there's a serious issue for Ionic users which I don't think would have any workaround.

The windows version of the plugin basically just creates a number of `<select>` elements to look like a native picker. As discussed in this blog post: http://www.intertech.com/Blog/windows-phone-ionic-cordova-select-element-issue/ there are issues with double clicking on select elements in Ionic. When I use this plugin and select a year, month or date, the native select menu "Choose one" appears, and then selecting one reveals the exact same select menu. So for every field you have to select twice, which is obviously not acceptable.

The resolution is to just set the "data-tap-disabled" attribute on the elements. I've tested this out and it works for me. I can't see any other way Ionic users could get round this issue, hence my proposed (very small) changes. However I do appreciate this is slightly odd to put a framework-specific fix in here.