### PR TITLE
Fix bug that didn't allow showing datepicker twice

### DIFF
--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -26,7 +26,7 @@ DatePicker.prototype.ANDROID_THEMES = {
  */
 DatePicker.prototype.show = function(options, cb, errCb) {
 
-	if (options.date) {
+	if (options.date && options.date instanceof Date) {
 		options.date = (options.date.getMonth() + 1) + "/" +
 					   (options.date.getDate()) + "/" +
 					   (options.date.getFullYear()) + "/" +


### PR DESCRIPTION
When a datepicker was shown, the options date property value was changed to a string, If one tried to show again the datepicker it would throw an error, because we were trying to treat date as a Date object, and it is already a String (objects are mutable in Javascript).

A workaround was to reinstantiate the options object everytime we show the datepicker, but it doesn't have to be that way.

So my solution was to check if the date attribute is a Date object, if so, change to string, if not, leave it as it is.