### PR TITLE
Fix inconsistent date option initialization logics in ios and android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+thumbs.db
+Thumbs.db
+.idea

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -26,17 +26,20 @@ DatePicker.prototype.ANDROID_THEMES = {
  */
 DatePicker.prototype.show = function(options, cb, errCb) {
 
-	if (options.date && options.date instanceof Date) {
-		options.date = (options.date.getMonth() + 1) + "/" +
-					   (options.date.getDate()) + "/" +
-					   (options.date.getFullYear()) + "/" +
-					   (options.date.getHours()) + "/" +
-					   (options.date.getMinutes());
-	}
+	if ( !options.date || options.date instanceof Date )
+		options.date = new Date();
+
+	options.date = [
+		options.date.getMonth() + 1,
+		options.date.getDate(),
+		options.date.getFullYear(),
+		options.date.getHours(),
+		options.date.getMinutes()
+	].join( '/' );
 
 	var defaults = {
 		mode : 'date',
-		date : '',
+		date : options.date,
 		minDate: 0,
 		maxDate: 0,
 		titleText: '',

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -26,7 +26,7 @@ DatePicker.prototype.ANDROID_THEMES = {
  */
 DatePicker.prototype.show = function(options, cb, errCb) {
 
-	if ( !options.date || options.date instanceof Date )
+	if ( !options.date || !(options.date instanceof Date) )
 		options.date = new Date();
 
 	options.date = [

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -1,150 +1,131 @@
 /**
-  Phonegap DatePicker Plugin
-  https://github.com/sectore/phonegap3-ios-datepicker-plugin
+ Phonegap DatePicker Plugin
+ https://github.com/sectore/phonegap3-ios-datepicker-plugin
 
-  Copyright (c) Greg Allen 2011
-  Additional refactoring by Sam de Freyssinet
+ Copyright (c) Greg Allen 2011
+ Additional refactoring by Sam de Freyssinet
 
-  Rewrite by Jens Krause (www.websector.de)
+ Rewrite by Jens Krause (www.websector.de)
 
-  MIT Licensed
-*/
+ MIT Licensed
+ */
 
-var exec = require('cordova/exec');
+var exec = require( 'cordova/exec' );
 /**
  * Constructor
  */
-function DatePicker() {
-    this._callback;
-}
+function DatePicker() { }
 
 /**
  * Android themes
  * @todo Avoid error when an Android theme is define...
  */
 DatePicker.prototype.ANDROID_THEMES = {
-  THEME_TRADITIONAL          : 1, // default
-  THEME_HOLO_DARK            : 2,
-  THEME_HOLO_LIGHT           : 3,
-  THEME_DEVICE_DEFAULT_DARK  : 4,
-  THEME_DEVICE_DEFAULT_LIGHT : 5
+	THEME_TRADITIONAL         : 1, // default
+	THEME_HOLO_DARK           : 2,
+	THEME_HOLO_LIGHT          : 3,
+	THEME_DEVICE_DEFAULT_DARK : 4,
+	THEME_DEVICE_DEFAULT_LIGHT: 5
 };
 
 /**
  * show - true to show the ad, false to hide the ad
  */
-DatePicker.prototype.show = function(options, cb) {
-    var padDate = function(date) {
-      if (date.length == 1) {
-        return ("0" + date);
-      }
-      return date;
-    };
+DatePicker.prototype.show = function( options, cb )
+{
+	if ( options.popoverArrowDirection )
+	{
+		options.popoverArrowDirection = this._popoverArrowDirectionIntegerFromString( options.popoverArrowDirection );
+		console.log( 'ha options', this, options.popoverArrowDirection );
+	}
 
-    var formatDate = function(date){
-      // date/minDate/maxDate will be string at second time
-      if (!(date instanceof Date)) {
-        date = new Date(date)
-      }
-      date = date.getFullYear()
-            + "-"
-            + padDate(date.getMonth()+1)
-            + "-"
-            + padDate(date.getDate())
-            + "T"
-            + padDate(date.getHours())
-            + ":"
-            + padDate(date.getMinutes())
-            + ":00Z";
+	var defaults = {
+		mode                 : options.mode || 'date',
+		date                 : formatDate( options.date || new Date() ),
+		allowOldDates        : options.allowOldDates || true,
+		allowFutureDates     : options.allowFutureDates || true,
+		minDate              : options.minDate ? formatDate( options.minDate ) : '',
+		maxDate              : options.maxDate ? formatDate( options.maxDate ) : '',
+		doneButtonLabel      : options.doneButtonLabel || 'Done',
+		doneButtonColor      : options.doneButtonColor || '#007AFF',
+		cancelButtonLabel    : options.cancelButtonLabel || 'Cancel',
+		cancelButtonColor    : options.cancelButtonColor || '#007AFF',
+		x                    : options.x || '0',
+		y                    : options.y || '0',
+		minuteInterval       : options.minuteInterval || 1,
+		popoverArrowDirection: options.popoverArrowDirection || this._popoverArrowDirectionIntegerFromString( "any" ),
+		locale               : options.locale || "en_US"
+	};
+	
+	this._callback = cb;
 
-      return date
-    }
+	exec( null, null, "DatePicker", "show", [ defaults ] );
 
-    if (options.date) {
-        options.date = formatDate(options.date);
-    }
 
-    if (options.minDate) {
-        options.minDate = formatDate(options.minDate);
-    }
 
-    if (options.maxDate) {
-        options.maxDate = formatDate(options.maxDate);
-    }
 
-    if (options.popoverArrowDirection) {
-        options.popoverArrowDirection = this._popoverArrowDirectionIntegerFromString(options.popoverArrowDirection);
-        console.log('ha options', this, options.popoverArrowDirection);
-    }
 
-    var defaults = {
-        mode: 'date',
-        date: new Date(),
-        allowOldDates: true,
-        allowFutureDates: true,
-        minDate: '',
-        maxDate: '',
-        doneButtonLabel: 'Done',
-        doneButtonColor: '#007AFF',
-        cancelButtonLabel: 'Cancel',
-        cancelButtonColor: '#007AFF',
-        locale: "NL",
-        x: '0',
-        y: '0',
-        minuteInterval: 1,
-        popoverArrowDirection: this._popoverArrowDirectionIntegerFromString("any"),
-        locale: "en_US"
-    };
 
-    for (var key in defaults) {
-        if (typeof options[key] !== "undefined")
-            defaults[key] = options[key];
-    }
-    this._callback = cb;
+	function padDate( date ) {
+		return ( date.length == 1  ? "0" : '') + date;
+	}
 
-    exec(null,
-      null,
-      "DatePicker",
-      "show",
-      [defaults]
-    );
+	function formatDate( date ) {
+		// date/minDate/maxDate will be string at second time
+		if ( !(date instanceof Date) ) {
+			date = new Date( date );
+		}
+
+
+		return [
+			date.getFullYear(),
+			"-",
+			padDate( date.getMonth() + 1 ),
+			"-",
+			padDate( date.getDate() ),
+			"T",
+			padDate( date.getHours() ),
+			":",
+			padDate( date.getMinutes() ),
+			":00Z"
+		].join( '' );
+	}
 };
 
-DatePicker.prototype._dateSelected = function(date) {
-    var d = new Date(parseFloat(date) * 1000);
-    if (this._callback)
-        this._callback(d);
+DatePicker.prototype._dateSelected = function( date ) {
+	var d = new Date( parseFloat( date ) * 1000 );
+	if ( this._callback )
+		this._callback( d );
 };
 
 DatePicker.prototype._dateSelectionCanceled = function() {
-    if (this._callback)
-        this._callback();
+	if ( this._callback )
+		this._callback();
 };
 
 DatePicker.prototype._UIPopoverArrowDirection = {
-    "up": 1,
-    "down": 2,
-    "left": 4,
-    "right": 8,
-    "any": 15
+	"up"   : 1,
+	"down" : 2,
+	"left" : 4,
+	"right": 8,
+	"any"  : 15
 };
 
-DatePicker.prototype._popoverArrowDirectionIntegerFromString = function (string) {
-    if (typeof this._UIPopoverArrowDirection[string] !== "undefined") {
-        return this._UIPopoverArrowDirection[string];
-    }
-    return this._UIPopoverArrowDirection.any;
+DatePicker.prototype._popoverArrowDirectionIntegerFromString = function( string ) {
+	if ( typeof this._UIPopoverArrowDirection[ string ] !== "undefined" ) {
+		return this._UIPopoverArrowDirection[ string ];
+	}
+	return this._UIPopoverArrowDirection.any;
 };
-
 
 
 var datePicker = new DatePicker();
 module.exports = datePicker;
 
 // Make plugin work under window.plugins
-if (!window.plugins) {
-    window.plugins = {};
+if ( !window.plugins ) {
+	window.plugins = {};
 }
-if (!window.plugins.datePicker) {
-    window.plugins.datePicker = datePicker;
+if ( !window.plugins.datePicker ) {
+	window.plugins.datePicker = datePicker;
 }


### PR DESCRIPTION
In iOS, date object with native toString will contain millisecond information which is not recognized in ios native code. In android, empty string will cause some similar exceptions.
I modify the parameter initialization logics in both iOS and Android to avoid these exceptions.
