### PR TITLE
making sure manually entered times are recognized correctly

### DIFF
--- a/src/android/DatePickerPlugin.java
+++ b/src/android/DatePickerPlugin.java
@@ -319,9 +319,12 @@ public class DatePickerPlugin extends CordovaPlugin {
 			if (canceled) {
 				return;
 			}
-			
-			calendarDate.set(Calendar.HOUR_OF_DAY, hourOfDay);
-			calendarDate.set(Calendar.MINUTE, minute);
+
+			// make sure all values are updated
+			view.clearFocus();
+
+			calendarDate.set(Calendar.HOUR_OF_DAY, view.getCurrentHour());
+			calendarDate.set(Calendar.MINUTE, view.getCurrentMinute());
 			calendarDate.set(Calendar.SECOND, 0);
 
 			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");


### PR DESCRIPTION
focus needs to be cleared, otherwise manually entered times are not correctly set if focus is still in input field
