### PR TITLE
Fix EXEC_BAD_ACCESS errors in swizzled_pluginInitialize(). Add hide() method for datepicker

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
 
     <keywords>cordova,phonegap,datepicker,android,ios,ios7,ios8,wp</keywords>
 
-    <repo>https://github.com/VitaliiBlagodir/cordova-plugin-datepicker.git</repo>
+    <repo>https://github.com/se1exin/cordova-plugin-datepicker</repo>
 
     <!-- android -->
     <platform name="android">
@@ -35,6 +35,7 @@
         <config-file target="config.xml" parent="/*">
         <feature name="DatePicker">
             <param name="ios-package" value="DatePicker"/>
+            <param name="onload" value="true" />
         </feature>
         </config-file>
 

--- a/src/ios/DatePicker.h
+++ b/src/ios/DatePicker.h
@@ -17,5 +17,6 @@
 }
 
 - (void)show:(CDVInvokedUrlCommand*)command;
+- (void)hide:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -34,6 +34,10 @@
 
 #pragma mark - UIDatePicker
 
+- (void)pluginInitialize {
+  NSLog(@"Init DatePicker");
+}
+
 - (void)show:(CDVInvokedUrlCommand*)command {
   NSMutableDictionary *options = [command argumentAtIndex:0];
   //if (isIPhone) {

--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -44,7 +44,7 @@
 }
 
 - (void)hide:(CDVInvokedUrlCommand*)command {
-  [self hideKeyboard];
+  [self hideDatepicker];
 }
 
 - (BOOL)showForPhone:(NSMutableDictionary *)options {
@@ -108,7 +108,7 @@
     return true;
 }
 
-- (void)hideKeyboard {
+- (void)hideDatepicker {
   //if (isIPhone) {
     CGRect frame = CGRectOffset(self.datePickerComponentsContainer.frame,
                                 0,
@@ -133,12 +133,12 @@
 #pragma mark - Actions
 - (IBAction)doneAction:(id)sender {
   [self jsDateSelected];
-  [self hideKeyboard];
+  [self hideDatepicker];
 }
   
 - (IBAction)cancelAction:(id)sender {
   [self jsCancel];
-  [self hideKeyboard];
+  [self hideDatepicker];
 }
 
 

--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -43,6 +43,10 @@
  // }
 }
 
+- (void)hide:(CDVInvokedUrlCommand*)command {
+  [self hideKeyboard];
+}
+
 - (BOOL)showForPhone:(NSMutableDictionary *)options {
   if(!self.datePickerContainer){
     [[NSBundle mainBundle] loadNibNamed:@"DatePicker" owner:self options:nil];
@@ -104,7 +108,7 @@
     return true;
 }
 
-- (void)hide {
+- (void)hideKeyboard {
   //if (isIPhone) {
     CGRect frame = CGRectOffset(self.datePickerComponentsContainer.frame,
                                 0,
@@ -129,12 +133,12 @@
 #pragma mark - Actions
 - (IBAction)doneAction:(id)sender {
   [self jsDateSelected];
-  [self hide];
+  [self hideKeyboard];
 }
   
 - (IBAction)cancelAction:(id)sender {
   [self jsCancel];
-  [self hide];
+  [self hideKeyboard];
 }
 
 

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -44,7 +44,7 @@ DatePicker.prototype.show = function(options, cb) {
     var formatDate = function(date){
       // date/minDate/maxDate will be string at second time
       if (!(date instanceof Date)) {
-        date = new Date(date)
+        date = new Date(date);
       }
       date = date.getFullYear()
             + "-"
@@ -57,7 +57,7 @@ DatePicker.prototype.show = function(options, cb) {
             + padDate(date.getMinutes())
             + ":00Z";
 
-      return date
+      return date;
     }
 
     if (options.date) {
@@ -88,7 +88,6 @@ DatePicker.prototype.show = function(options, cb) {
         doneButtonColor: '#007AFF',
         cancelButtonLabel: 'Cancel',
         cancelButtonColor: '#007AFF',
-        locale: "NL",
         x: '0',
         y: '0',
         minuteInterval: 1,

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -109,6 +109,14 @@ DatePicker.prototype.show = function(options, cb) {
     );
 };
 
+DatePicker.prototype.hide = function() {
+    exec(null,
+      null,
+      "DatePicker",
+      "hide"
+    );
+};
+
 DatePicker.prototype._dateSelected = function(date) {
     var d = new Date(parseFloat(date) * 1000);
     if (this._callback)


### PR DESCRIPTION
I required this functionality to auto-hide the date picker after it has been open for too long.

Only implemented for iOS at this time.
