### PR TITLE
add history/update type of minDate/maxDate for android/fixed bug for ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Type: Date | empty String
 
 Default: `(empty String)`
 
+### history - iOS, Android
+Remember the date you last selected， show the date when you select again
+
+Type: Boolean
+
+Values: `true` | `false`
+
+Default: `false`
+
 ### titleText - Android
 Label for the dialog title. If empty, uses android default (Set date/Set time).
 

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -8,6 +8,7 @@
  */
 function DatePicker() {
   //this._callback;
+    this.history
 }
 
 /**
@@ -26,13 +27,29 @@ DatePicker.prototype.ANDROID_THEMES = {
  */
 DatePicker.prototype.show = function(options, cb, errCb) {
 
-	if (options.date && options.date instanceof Date) {
-		options.date = (options.date.getMonth() + 1) + "/" +
-					   (options.date.getDate()) + "/" +
-					   (options.date.getFullYear()) + "/" +
-					   (options.date.getHours()) + "/" +
-					   (options.date.getMinutes());
-	}
+    var formatDate = function(date) {
+      return Date.parse(new Date(date))
+    }
+    
+    if (options.history && this.history) {
+      options.date = this.history;
+    }
+    
+    if (options.date && options.date instanceof Date) {
+      options.date = (options.date.getMonth() + 1) + "/" +
+        (options.date.getDate()) + "/" +
+        (options.date.getFullYear()) + "/" +
+        (options.date.getHours()) + "/" +
+        (options.date.getMinutes());
+    }
+
+    if (options.minDate) {
+      options.minDate = formatDate(options.minDate);
+    }
+
+    if (options.maxDate) {
+      options.maxDate = formatDate(options.maxDate);
+    }
 
 	var defaults = {
 		mode : 'date',
@@ -55,11 +72,12 @@ DatePicker.prototype.show = function(options, cb, errCb) {
 	}
 
 	//this._callback = cb;
-
+        var _this = this;
 	var callback = function(message) {
 		if(message != 'error'){
 			var timestamp = Date.parse(message);
 			if(isNaN(timestamp) == false) {
+                                _this.history = new Date(message)
 				cb(new Date(message));
 			}
 	        else {

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -45,7 +45,7 @@ DatePicker.prototype.show = function(options, cb) {
     var formatDate = function(date){
       // date/minDate/maxDate will be string at second time
       if (!(date instanceof Date)) {
-        date = new Date(date)
+        return date
       }
       date = date.getFullYear()
             + "-"

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -16,6 +16,7 @@ var exec = require('cordova/exec');
  */
 function DatePicker() {
     this._callback;
+    this.history;
 }
 
 /**
@@ -35,7 +36,7 @@ DatePicker.prototype.ANDROID_THEMES = {
  */
 DatePicker.prototype.show = function(options, cb) {
     var padDate = function(date) {
-      if (date.length == 1) {
+      if (date.toString().length == 1) {
         return ("0" + date);
       }
       return date;
@@ -61,7 +62,10 @@ DatePicker.prototype.show = function(options, cb) {
     }
 
     if (options.date) {
-        options.date = formatDate(options.date);
+      if (options.history && this.history) {
+        options.date = this.history
+      }
+      options.date = formatDate(options.date);
     }
 
     if (options.minDate) {
@@ -112,6 +116,7 @@ DatePicker.prototype.show = function(options, cb) {
 
 DatePicker.prototype._dateSelected = function(date) {
     var d = new Date(parseFloat(date) * 1000);
+    this.history = d;
     if (this._callback)
         this._callback(d);
 };


### PR DESCRIPTION
thanks for your plugin, recently I use it in my project, at the same time, I also found some problems. hoping to help 
### 1. add an option about history

remember the date you last selected and show the date when you select again
### 2. use the date object as minDate or maxDate for  Android

e. g.

```
maxDate: new Date()
```
### 3. fixed bug for ios

the variable **date** in the function **padDate** is number, the property length of date is undefined
