### PR TITLE
Patch for iOS where date picker fails when using the default date sin…

### DIFF
--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -79,7 +79,7 @@ DatePicker.prototype.show = function(options, cb) {
 
     var defaults = {
         mode: 'date',
-        date: new Date(),
+        date: formatDate(new Date()),
         allowOldDates: true,
         allowFutureDates: true,
         minDate: '',


### PR DESCRIPTION
Updated DatePicker.js for iOS so the "default" date is formatted like a date that is passed into the show method
