### PR TITLE
Prevent cancel button from raising exception

### DIFF
--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -145,10 +145,10 @@
 #pragma mark - JS API
 
 - (void)jsCancel {
-  NSLog(@"JS Cancel is going to be executed");
-  NSString *jsCallback = @"datePicker._dateSelectionCanceled();";
+  // NSLog(@"JS Cancel is going to be executed");
+  // NSString *jsCallback = @"datePicker._dateSelectionCanceled();";
     
-  [self.commandDelegate evalJs:jsCallback];
+  // [self.commandDelegate evalJs:jsCallback];
 }
 
 - (void)jsDateSelected {


### PR DESCRIPTION
Pressing cancel on a picker currently crashes leaving a null value behind in the field. If we just skip the call to the JS cancel function this doesn't happen, the picker closes correctly and everything seems okay.

Fixes #204