### PR TITLE
Allow Date object to be used for minDate & maxDate on Android, like iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Type: Date | empty String
 
 Default: `(empty String)`
 
-minDate is a Date object for iOS and a millisecond precision unix timestamp for Android, so you need to account for that when using the plugin. Also, on Android, only the date is enforced (time is not).
+minDate is a Date object. On Android, only the date is enforced (time is not).
 
 ### maxDate - iOS, Android, Windows
 Maximum date.
@@ -92,6 +92,8 @@ Maximum date.
 Type: Date | empty String
 
 Default: `(empty String)`
+
+maxDate is a Date object. On Android, only the date is enforced (time is not).
 
 ### titleText - Android
 Label for the dialog title. If empty, uses android default (Set date/Set time).

--- a/www/android/DatePicker.js
+++ b/www/android/DatePicker.js
@@ -34,6 +34,14 @@ DatePicker.prototype.show = function(options, cb, errCb) {
 					   (options.date.getMinutes());
 	}
 
+	if (options.minDate && options.minDate instanceof Date) {
+		options.minDate = options.minDate.valueOf()
+	}
+
+	if (options.maxDate && options.maxDate instanceof Date) {
+		options.maxDate = options.maxDate.valueOf()
+	}
+
 	var defaults = {
 		mode : 'date',
 		date : '',


### PR DESCRIPTION
This PR contains changes that make the minDate & maxDate api the same for Android and iOS. Before, users had to check the platform and transform their date, eg. using `.valueOf()` to transform it into milliseconds, before passing it to this plugin. With these changes, both platforms can pass a Date object and it will be transformed appropriately.