### PR TITLE
On cancel resets date bug

### DIFF
--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -117,8 +117,8 @@ DatePicker.prototype._dateSelected = function(date) {
 };
 
 DatePicker.prototype._dateSelectionCanceled = function() {
-    if (this._callback)
-        this._callback();
+//     if (this._callback)
+//         this._callback();
 };
 
 DatePicker.prototype._UIPopoverArrowDirection = {


### PR DESCRIPTION
When commenting out these two lines, a bug is fixed where when the datepicker cancels, it returns nothing. This is probably not the final solution but might help you track down the underlying issue.