### PR TITLE
Allow dark theme on iOS 13+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ Values: `THEME_TRADITIONAL | THEME_HOLO_DARK | THEME_HOLO_LIGHT | THEME_DEVICE_D
 
 Default: `THEME_TRADITIONAL`
 
+### theme - iOS
+Choose the theme of the picker
+
+Type: String
+
+Values: `light | dark`
+
+Default: `light`
+
 ### allowOldDates - iOS
 Shows or hide dates earlier then selected date.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-datepicker",
+  "name": "@journeyapps/cordova-plugin-datepicker",
   "version": "0.9.2",
   "description": "Cordova DatePicker Plugin",
   "cordova": {
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/VitaliiBlagodir/cordova-plugin-datepicker.git"
+    "url": "https://github.com/journeyapps/cordova-plugin-datepicker"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,6 +45,7 @@
         <header-file src="src/ios/DatePicker.h" />
         <source-file src="src/ios/DatePicker.m" />
         <resource-file src="src/ios/DatePicker.xib" />
+        <resource-file src="src/ios/DatePickerDark.xib" />
     </platform>
 	
     <!-- windows -->

--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -44,10 +44,18 @@
 }
 
 - (BOOL)showForPhone:(NSMutableDictionary *)options {
-  if(!self.datePickerContainer){
-    [[NSBundle mainBundle] loadNibNamed:@"DatePicker" owner:self options:nil];
+  if (@available(iOS 13.0, *)) {
+    NSString *theme = [options objectForKey:@"theme"];
+
+    if ([theme isEqualToString:@"dark"] ) {
+      [[NSBundle mainBundle] loadNibNamed:@"DatePickerDark" owner:self options:nil];
+      self.datePickerContainer.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    } else {
+      [[NSBundle mainBundle] loadNibNamed:@"DatePicker" owner:self options:nil];
+      self.datePickerContainer.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
   } else {
-      self.datePickerContainer.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
+    [[NSBundle mainBundle] loadNibNamed:@"DatePicker" owner:self options:nil];
   }
   
   [self updateDatePicker:options];

--- a/src/ios/DatePickerDark.xib
+++ b/src/ios/DatePickerDark.xib
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="DatePicker">
+            <connections>
+                <outlet property="cancelButton" destination="xq4-6B-F5W" id="BDR-WE-Trb"/>
+                <outlet property="datePicker" destination="SUg-U1-bKY" id="aaa-Vr-qUb"/>
+                <outlet property="datePickerComponentsContainer" destination="b2J-jW-BgT" id="jYk-bM-1Mz"/>
+                <outlet property="datePickerComponentsContainerVSpace" destination="Pz2-m8-ZCU" id="HyH-ku-Omg"/>
+                <outlet property="datePickerContainer" destination="1" id="tz5-zN-epC"/>
+                <outlet property="doneButton" destination="FEs-Wn-Ur2" id="UaP-7S-x5K"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view opaque="NO" contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b2J-jW-BgT">
+                    <rect key="frame" x="0.0" y="354" width="320" height="216"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CHZ-tf-She">
+                            <rect key="frame" x="0.0" y="54" width="320" height="180"/>
+                            <subviews>
+                                <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="SUg-U1-bKY">
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="162"/>
+                                    <date key="date" timeIntervalSinceReferenceDate="408285701.96363503">
+                                        <!--2013-12-09 12:41:41 +0000-->
+                                    </date>
+                                </datePicker>
+                            </subviews>
+                            <color key="backgroundColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="SUg-U1-bKY" secondAttribute="bottom" constant="18" id="BFv-4x-nTt"/>
+                                <constraint firstAttribute="centerX" secondItem="SUg-U1-bKY" secondAttribute="centerX" id="HX3-eJ-dgx"/>
+                                <constraint firstItem="SUg-U1-bKY" firstAttribute="top" secondItem="CHZ-tf-She" secondAttribute="top" id="QPo-jn-T5C"/>
+                            </constraints>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xq4-6B-F5W">
+                            <rect key="frame" x="0.0" y="8" width="155" height="46"/>
+                            <color key="backgroundColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="46" id="rdQ-Si-ceK"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                            <inset key="contentEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
+                            <state key="normal" title="cancel button">
+                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </state>
+                            <connections>
+                                <action selector="cancelAction:" destination="-1" eventType="touchUpInside" id="blS-dS-tPm"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalCompressionResistancePriority="751" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FEs-Wn-Ur2">
+                            <rect key="frame" x="165" y="8" width="155" height="46"/>
+                            <color key="backgroundColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                            <inset key="contentEdgeInsets" minX="0.0" minY="0.0" maxX="20" maxY="0.0"/>
+                            <state key="normal" title="done button">
+                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </state>
+                            <connections>
+                                <action selector="doneAction:" destination="-1" eventType="touchUpInside" id="Yt2-gL-WnC"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="FEs-Wn-Ur2" firstAttribute="height" secondItem="xq4-6B-F5W" secondAttribute="height" id="0XS-oZ-CNe"/>
+                        <constraint firstAttribute="height" constant="216" id="9uR-69-zFL"/>
+                        <constraint firstItem="FEs-Wn-Ur2" firstAttribute="width" secondItem="xq4-6B-F5W" secondAttribute="width" id="Gl0-Ut-zPZ"/>
+                        <constraint firstItem="CHZ-tf-She" firstAttribute="leading" secondItem="b2J-jW-BgT" secondAttribute="leading" id="NUO-OT-Yul"/>
+                        <constraint firstAttribute="trailing" secondItem="CHZ-tf-She" secondAttribute="trailing" id="Pds-Eg-BO8"/>
+                        <constraint firstAttribute="bottom" secondItem="CHZ-tf-She" secondAttribute="bottom" constant="-18" id="Pz2-m8-ZCU"/>
+                        <constraint firstItem="xq4-6B-F5W" firstAttribute="top" secondItem="b2J-jW-BgT" secondAttribute="top" constant="8" id="bcc-2v-8aw"/>
+                        <constraint firstItem="xq4-6B-F5W" firstAttribute="top" secondItem="FEs-Wn-Ur2" secondAttribute="top" id="n2U-fL-D2y"/>
+                        <constraint firstItem="CHZ-tf-She" firstAttribute="trailing" secondItem="FEs-Wn-Ur2" secondAttribute="trailing" id="uef-vO-KLf"/>
+                        <constraint firstItem="FEs-Wn-Ur2" firstAttribute="leading" secondItem="xq4-6B-F5W" secondAttribute="trailing" constant="10" id="wS8-8a-p64"/>
+                        <constraint firstItem="CHZ-tf-She" firstAttribute="top" secondItem="FEs-Wn-Ur2" secondAttribute="bottom" id="wo1-5V-ljM"/>
+                        <constraint firstItem="CHZ-tf-She" firstAttribute="leading" secondItem="xq4-6B-F5W" secondAttribute="leading" id="yLp-P8-0xk"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <constraints>
+                <constraint firstItem="b2J-jW-BgT" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="7Cn-9l-1Ra"/>
+                <constraint firstAttribute="trailing" secondItem="b2J-jW-BgT" secondAttribute="trailing" id="ftU-Z8-LOZ"/>
+                <constraint firstAttribute="bottom" secondItem="b2J-jW-BgT" secondAttribute="bottom" constant="-2" id="v9p-KT-uOF"/>
+            </constraints>
+        </view>
+        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" id="uRz-8Y-jzJ">
+            <rect key="frame" x="0.0" y="0.0" width="37" height="37"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        </activityIndicatorView>
+    </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/www/ios/DatePicker.js
+++ b/www/ios/DatePicker.js
@@ -93,7 +93,8 @@ DatePicker.prototype.show = function(options, cb) {
         y: '0',
         minuteInterval: 1,
         popoverArrowDirection: this._popoverArrowDirectionIntegerFromString("any"),
-        locale: "en_US"
+        locale: "en_US",
+        theme: 'light'
     };
 
     for (var key in defaults) {


### PR DESCRIPTION
Dark theme on iOS 13+.

We use a separate `.xib` for the dark theme and override the theme using `UIUserInterfaceStyleDark` for the datepicker's text.